### PR TITLE
Add generation on runtime of *all* virtual methods.

### DIFF
--- a/addons/script-ide/plugin.gd
+++ b/addons/script-ide/plugin.gd
@@ -5,29 +5,7 @@ const OUTLINE_POPUP_TRIGGER: Key = KeyModifierMask.KEY_MASK_CTRL + Key.KEY_O
 const OUTLINE_POPUP_TRIGGER_ALT: Key = KeyModifierMask.KEY_MASK_META + Key.KEY_O
 const POPUP_SCRIPT: GDScript = preload("res://addons/script-ide/Popup.gd")
 
-const keywords: Dictionary = {
-	"_ready": 0,
-	"_process": 0,
-	"_physics_process": 0,
-	"_init": 0,
-	"_enter_tree": 0,
-	"_exit_tree": 0,
-	"_unhandled_input": 0,
-	"_input": 0,
-	"_unhandled_key_input": 0,
-	"_draw": 0,
-	"_notification": 0,
-	"_to_string": 0,
-	"_get": 0,
-	"_get_property_list": 0,
-	"_set": 0,
-	"_property_can_revert": 0,
-	"_property_get_revert": 0,
-	"_gui_input": 0,
-	"_get_drag_data": 0,
-	"_drop_data": 0,
-	"_can_drop_data": 0
-}
+static var keywords: Dictionary = {}
 
 const keyword_icon: Texture2D = preload("res://addons/script-ide/icon/keyword.png")
 const func_icon: Texture2D = preload("res://addons/script-ide/icon/func.png")
@@ -71,6 +49,12 @@ var last_tab_hovered: int = -1
 
 var outline_container: Node
 var popup: PopupPanel
+
+static func register_virtual_methods(cls: String)->void:
+	for method in ClassDB.class_get_method_list(cls):
+		if method.flags & METHOD_FLAG_VIRTUAL > 0:
+			keywords[method.name]=0
+	
 
 func _enter_tree() -> void:
 	# Update on save
@@ -162,6 +146,9 @@ func _enter_tree() -> void:
 		scripts_item_list.get_parent().visible = false
 			
 	attach_script_listener(script_editor.get_current_script())
+	register_virtual_methods("Object")
+	for subcls in ClassDB.get_inheriters_from_class("Object"):
+		register_virtual_methods(subcls)
 
 func _exit_tree() -> void:
 	var file_system: EditorFileSystem = get_editor_interface().get_resource_filesystem()

--- a/addons/script-ide/plugin.gd
+++ b/addons/script-ide/plugin.gd
@@ -149,6 +149,7 @@ func _enter_tree() -> void:
 	register_virtual_methods("Object")
 	for subcls in ClassDB.get_inheriters_from_class("Object"):
 		register_virtual_methods(subcls)
+	keywords["_static_init"]=0
 
 func _exit_tree() -> void:
 	var file_system: EditorFileSystem = get_editor_interface().get_resource_filesystem()


### PR DESCRIPTION
fixes #5 
List for godot 4.1.1 stable:
["_notification", "_set", "_get", "_get_property_list", "_property_can_revert", "_property_get_revert", "_init", "_to_string", "_get_recognized_extensions", "_recognize_path", "_handles_type", "_get_resource_type", "_get_resource_script_class", "_get_resource_uid", "_get_dependencies", "_rename_dependencies", "_exists", "_get_classes_used", "_load", "_save", "_set_uid", "_recognize", "_get_rid", "_editor_can_reload_from_file", "_placeholder_erased", "_can_instantiate", "_get_base_script", "_get_global_name", "_inherits_script", "_get_instance_base_type", "_instance_create", "_placeholder_instance_create", "_instance_has", "_has_source_code", "_get_source_code", "_set_source_code", "_reload", "_get_documentation", "_has_method", "_get_method_info", "_is_tool", "_is_valid", "_get_language", "_has_script_signal", "_get_script_signal_list", "_has_property_default_value", "_get_property_default_value", "_update_exports", "_get_script_method_list", "_get_script_property_list", "_get_member_line", "_get_constants", "_get_members", "_is_placeholder_fallback_enabled", "_get_rpc_config", "_get_name", "_get_type", "_get_extension", "_finish", "_get_reserved_words", "_is_control_flow_keyword", "_get_comment_delimiters", "_get_string_delimiters", "_make_template", "_get_built_in_templates", "_is_using_templates", "_validate", "_validate_path", "_create_script", "_has_named_classes", "_supports_builtin_mode", "_supports_documentation", "_can_inherit_from_file", "_find_function", "_make_function", "_open_in_external_editor", "_overrides_external_editor", "_complete_code", "_lookup_code", "_auto_indent_code", "_add_global_constant", "_add_named_global_constant", "_remove_named_global_constant", "_thread_enter", "_thread_exit", "_debug_get_error", "_debug_get_stack_level_count", "_debug_get_stack_level_line", "_debug_get_stack_level_function", "_debug_get_stack_level_locals", "_debug_get_stack_level_members", "_debug_get_stack_level_instance", "_debug_get_globals", "_debug_parse_stack_level_expression", "_debug_get_current_stack_info", "_reload_all_scripts", "_reload_tool_script", "_get_public_functions", "_get_public_constants", "_get_public_annotations", "_profiling_start", "_profiling_stop", "_profiling_get_accumulated_data", "_profiling_get_frame_data", "_frame", "_handles_global_class_type", "_get_global_class_name", "_get_data", "_get_partial_data", "_put_data", "_put_partial_data", "_get_available_bytes", "_get_packet", "_put_packet", "_get_available_packet_count", "_get_max_packet_size", "_initialize", "_physics_process", "_process", "_finalize", "_get_plural_message", "_get_message", "_estimate_cost", "_compute_cost", "_load_image", "_toggle", "_add_frame", "_tick", "_has_feature", "_get_features", "_free_rid", "_has", "_load_support_data", "_get_support_data_filename", "_get_support_data_info", "_save_support_data", "_is_locale_right_to_left", "_name_to_tag", "_tag_to_name", "_create_font", "_font_set_data", "_font_set_data_ptr", "_font_set_face_index", "_font_get_face_index", "_font_get_face_count", "_font_set_style", "_font_get_style", "_font_set_name", "_font_get_name", "_font_get_ot_name_strings", "_font_set_style_name", "_font_get_style_name", "_font_set_weight", "_font_get_weight", "_font_set_stretch", "_font_get_stretch", "_font_set_antialiasing", "_font_get_antialiasing", "_font_set_generate_mipmaps", "_font_get_generate_mipmaps", "_font_set_multichannel_signed_distance_field", "_font_is_multichannel_signed_distance_field", "_font_set_msdf_pixel_range", "_font_get_msdf_pixel_range", "_font_set_msdf_size", "_font_get_msdf_size", "_font_set_fixed_size", "_font_get_fixed_size", "_font_set_allow_system_fallback", "_font_is_allow_system_fallback", "_font_set_force_autohinter", "_font_is_force_autohinter", "_font_set_hinting", "_font_get_hinting", "_font_set_subpixel_positioning", "_font_get_subpixel_positioning", "_font_set_embolden", "_font_get_embolden", "_font_set_transform", "_font_get_transform", "_font_set_variation_coordinates", "_font_get_variation_coordinates", "_font_set_oversampling", "_font_get_oversampling", "_font_get_size_cache_list", "_font_clear_size_cache", "_font_remove_size_cache", "_font_set_ascent", "_font_get_ascent", "_font_set_descent", "_font_get_descent", "_font_set_underline_position", "_font_get_underline_position", "_font_set_underline_thickness", "_font_get_underline_thickness", "_font_set_scale", "_font_get_scale", "_font_get_texture_count", "_font_clear_textures", "_font_remove_texture", "_font_set_texture_image", "_font_get_texture_image", "_font_set_texture_offsets", "_font_get_texture_offsets", "_font_get_glyph_list", "_font_clear_glyphs", "_font_remove_glyph", "_font_get_glyph_advance", "_font_set_glyph_advance", "_font_get_glyph_offset", "_font_set_glyph_offset", "_font_get_glyph_size", "_font_set_glyph_size", "_font_get_glyph_uv_rect", "_font_set_glyph_uv_rect", "_font_get_glyph_texture_idx", "_font_set_glyph_texture_idx", "_font_get_glyph_texture_rid", "_font_get_glyph_texture_size", "_font_get_glyph_contours", "_font_get_kerning_list", "_font_clear_kerning_map", "_font_remove_kerning", "_font_set_kerning", "_font_get_kerning", "_font_get_glyph_index", "_font_get_char_from_glyph_index", "_font_has_char", "_font_get_supported_chars", "_font_render_range", "_font_render_glyph", "_font_draw_glyph", "_font_draw_glyph_outline", "_font_is_language_supported", "_font_set_language_support_override", "_font_get_language_support_override", "_font_remove_language_support_override", "_font_get_language_support_overrides", "_font_is_script_supported", "_font_set_script_support_override", "_font_get_script_support_override", "_font_remove_script_support_override", "_font_get_script_support_overrides", "_font_set_opentype_feature_overrides", "_font_get_opentype_feature_overrides", "_font_supported_feature_list", "_font_supported_variation_list", "_font_get_global_oversampling", "_font_set_global_oversampling", "_get_hex_code_box_size", "_draw_hex_code_box", "_create_shaped_text", "_shaped_text_clear", "_shaped_text_set_direction", "_shaped_text_get_direction", "_shaped_text_get_inferred_direction", "_shaped_text_set_bidi_override", "_shaped_text_set_custom_punctuation", "_shaped_text_get_custom_punctuation", "_shaped_text_set_orientation", "_shaped_text_get_orientation", "_shaped_text_set_preserve_invalid", "_shaped_text_get_preserve_invalid", "_shaped_text_set_preserve_control", "_shaped_text_get_preserve_control", "_shaped_text_set_spacing", "_shaped_text_get_spacing", "_shaped_text_add_string", "_shaped_text_add_object", "_shaped_text_resize_object", "_shaped_get_span_count", "_shaped_get_span_meta", "_shaped_set_span_update_font", "_shaped_text_substr", "_shaped_text_get_parent", "_shaped_text_fit_to_width", "_shaped_text_tab_align", "_shaped_text_shape", "_shaped_text_update_breaks", "_shaped_text_update_justification_ops", "_shaped_text_is_ready", "_shaped_text_get_glyphs", "_shaped_text_sort_logical", "_shaped_text_get_glyph_count", "_shaped_text_get_range", "_shaped_text_get_line_breaks_adv", "_shaped_text_get_line_breaks", "_shaped_text_get_word_breaks", "_shaped_text_get_trim_pos", "_shaped_text_get_ellipsis_pos", "_shaped_text_get_ellipsis_glyph_count", "_shaped_text_get_ellipsis_glyphs", "_shaped_text_overrun_trim_to_width", "_shaped_text_get_objects", "_shaped_text_get_object_rect", "_shaped_text_get_size", "_shaped_text_get_ascent", "_shaped_text_get_descent", "_shaped_text_get_width", "_shaped_text_get_underline_position", "_shaped_text_get_underline_thickness", "_shaped_text_get_dominant_direction_in_range", "_shaped_text_get_carets", "_shaped_text_get_selection", "_shaped_text_hit_test_grapheme", "_shaped_text_hit_test_position", "_shaped_text_draw", "_shaped_text_draw_outline", "_shaped_text_get_grapheme_bounds", "_shaped_text_next_grapheme_pos", "_shaped_text_prev_grapheme_pos", "_format_number", "_parse_number", "_percent_sign", "_strip_diacritics", "_is_valid_identifier", "_string_get_word_breaks", "_is_confusable", "_spoof_check", "_string_to_upper", "_string_to_lower", "_parse_structured_text", "_cleanup", "_world_boundary_shape_create", "_separation_ray_shape_create", "_segment_shape_create", "_circle_shape_create", "_rectangle_shape_create", "_capsule_shape_create", "_convex_polygon_shape_create", "_concave_polygon_shape_create", "_shape_set_data", "_shape_set_custom_solver_bias", "_shape_get_type", "_shape_get_data", "_shape_get_custom_solver_bias", "_shape_collide", "_space_create", "_space_set_active", "_space_is_active", "_space_set_param", "_space_get_param", "_space_get_direct_state", "_space_set_debug_contacts", "_space_get_contacts", "_space_get_contact_count", "_area_create", "_area_set_space", "_area_get_space", "_area_add_shape", "_area_set_shape", "_area_set_shape_transform", "_area_set_shape_disabled", "_area_get_shape_count", "_area_get_shape", "_area_get_shape_transform", "_area_remove_shape", "_area_clear_shapes", "_area_attach_object_instance_id", "_area_get_object_instance_id", "_area_attach_canvas_instance_id", "_area_get_canvas_instance_id", "_area_set_param", "_area_set_transform", "_area_get_param", "_area_get_transform", "_area_set_collision_layer", "_area_get_collision_layer", "_area_set_collision_mask", "_area_get_collision_mask", "_area_set_monitorable", "_area_set_pickable", "_area_set_monitor_callback", "_area_set_area_monitor_callback", "_body_create", "_body_set_space", "_body_get_space", "_body_set_mode", "_body_get_mode", "_body_add_shape", "_body_set_shape", "_body_set_shape_transform", "_body_get_shape_count", "_body_get_shape", "_body_get_shape_transform", "_body_set_shape_disabled", "_body_set_shape_as_one_way_collision", "_body_remove_shape", "_body_clear_shapes", "_body_attach_object_instance_id", "_body_get_object_instance_id", "_body_attach_canvas_instance_id", "_body_get_canvas_instance_id", "_body_set_continuous_collision_detection_mode", "_body_get_continuous_collision_detection_mode", "_body_set_collision_layer", "_body_get_collision_layer", "_body_set_collision_mask", "_body_get_collision_mask", "_body_set_collision_priority", "_body_get_collision_priority", "_body_set_param", "_body_get_param", "_body_reset_mass_properties", "_body_set_state", "_body_get_state", "_body_apply_central_impulse", "_body_apply_torque_impulse", "_body_apply_impulse", "_body_apply_central_force", "_body_apply_force", "_body_apply_torque", "_body_add_constant_central_force", "_body_add_constant_force", "_body_add_constant_torque", "_body_set_constant_force", "_body_get_constant_force", "_body_set_constant_torque", "_body_get_constant_torque", "_body_set_axis_velocity", "_body_add_collision_exception", "_body_remove_collision_exception", "_body_get_collision_exceptions", "_body_set_max_contacts_reported", "_body_get_max_contacts_reported", "_body_set_contacts_reported_depth_threshold", "_body_get_contacts_reported_depth_threshold", "_body_set_omit_force_integration", "_body_is_omitting_force_integration", "_body_set_state_sync_callback", "_body_set_force_integration_callback", "_body_collide_shape", "_body_set_pickable", "_body_get_direct_state", "_body_test_motion", "_joint_create", "_joint_clear", "_joint_set_param", "_joint_get_param", "_joint_disable_collisions_between_bodies", "_joint_is_disabled_collisions_between_bodies", "_joint_make_pin", "_joint_make_groove", "_joint_make_damped_spring", "_pin_joint_set_param", "_pin_joint_get_param", "_damped_spring_joint_set_param", "_damped_spring_joint_get_param", "_joint_get_type", "_set_active", "_step", "_sync", "_flush_queries", "_end_sync", "_is_flushing_queries", "_get_process_info", "_get_total_gravity", "_get_total_linear_damp", "_get_total_angular_damp", "_get_center_of_mass", "_get_center_of_mass_local", "_get_inverse_mass", "_get_inverse_inertia", "_set_linear_velocity", "_get_linear_velocity", "_set_angular_velocity", "_get_angular_velocity", "_set_transform", "_get_transform", "_get_velocity_at_local_position", "_apply_central_impulse", "_apply_impulse", "_apply_torque_impulse", "_apply_central_force", "_apply_force", "_apply_torque", "_add_constant_central_force", "_add_constant_force", "_add_constant_torque", "_set_constant_force", "_get_constant_force", "_set_constant_torque", "_get_constant_torque", "_set_sleep_state", "_is_sleeping", "_get_contact_count", "_get_contact_local_position", "_get_contact_local_normal", "_get_contact_local_shape", "_get_contact_local_velocity_at_position", "_get_contact_collider", "_get_contact_collider_position", "_get_contact_collider_id", "_get_contact_collider_object", "_get_contact_collider_shape", "_get_contact_collider_velocity_at_position", "_get_contact_impulse", "_get_step", "_integrate_forces", "_get_space_state", "_intersect_ray", "_intersect_point", "_intersect_shape", "_cast_motion", "_collide_shape", "_rest_info", "_sphere_shape_create", "_box_shape_create", "_cylinder_shape_create", "_heightmap_shape_create", "_custom_shape_create", "_shape_set_margin", "_shape_get_margin", "_area_set_ray_pickable", "_body_set_enable_continuous_collision_detection", "_body_is_continuous_collision_detection_enabled", "_body_set_user_flags", "_body_get_user_flags", "_body_set_axis_lock", "_body_is_axis_locked", "_body_set_ray_pickable", "_soft_body_create", "_soft_body_update_rendering_server", "_soft_body_set_space", "_soft_body_get_space", "_soft_body_set_ray_pickable", "_soft_body_set_collision_layer", "_soft_body_get_collision_layer", "_soft_body_set_collision_mask", "_soft_body_get_collision_mask", "_soft_body_add_collision_exception", "_soft_body_remove_collision_exception", "_soft_body_get_collision_exceptions", "_soft_body_set_state", "_soft_body_get_state", "_soft_body_set_transform", "_soft_body_set_simulation_precision", "_soft_body_get_simulation_precision", "_soft_body_set_total_mass", "_soft_body_get_total_mass", "_soft_body_set_linear_stiffness", "_soft_body_get_linear_stiffness", "_soft_body_set_pressure_coefficient", "_soft_body_get_pressure_coefficient", "_soft_body_set_damping_coefficient", "_soft_body_get_damping_coefficient", "_soft_body_set_drag_coefficient", "_soft_body_get_drag_coefficient", "_soft_body_set_mesh", "_soft_body_get_bounds", "_soft_body_move_point", "_soft_body_get_point_global_position", "_soft_body_remove_all_pinned_points", "_soft_body_pin_point", "_soft_body_is_point_pinned", "_pin_joint_set_local_a", "_pin_joint_get_local_a", "_pin_joint_set_local_b", "_pin_joint_get_local_b", "_joint_make_hinge", "_joint_make_hinge_simple", "_hinge_joint_set_param", "_hinge_joint_get_param", "_hinge_joint_set_flag", "_hinge_joint_get_flag", "_joint_make_slider", "_slider_joint_set_param", "_slider_joint_get_param", "_joint_make_cone_twist", "_cone_twist_joint_set_param", "_cone_twist_joint_get_param", "_joint_make_generic_6dof", "_generic_6dof_joint_set_param", "_generic_6dof_joint_get_param", "_generic_6dof_joint_set_flag", "_generic_6dof_joint_get_flag", "_joint_set_solver_priority", "_joint_get_solver_priority", "_get_principal_inertia_axes", "_get_inverse_inertia_tensor", "_get_closest_point_to_object_volume", "_set_vertex", "_set_normal", "_set_aabb", "_get_capabilities", "_is_initialized", "_uninitialize", "_get_system_info", "_supports_play_area_mode", "_get_play_area_mode", "_set_play_area_mode", "_get_play_area", "_get_render_target_size", "_get_view_count", "_get_camera_transform", "_get_transform_for_view", "_get_projection_for_view", "_get_vrs_texture", "_pre_render", "_pre_draw_viewport", "_post_draw_viewport", "_end_frame", "_get_suggested_tracker_names", "_get_suggested_pose_names", "_get_tracking_status", "_trigger_haptic_pulse", "_get_anchor_detection_is_enabled", "_set_anchor_detection_is_enabled", "_get_camera_feed_id", "_get_color_texture", "_get_depth_texture", "_get_velocity_texture", "_instantiate_playback", "_get_stream_name", "_get_length", "_is_monophonic", "_get_bpm", "_get_beat_count", "_start", "_stop", "_is_playing", "_get_loop_count", "_get_playback_position", "_seek", "_mix", "_tag_used_streams", "_mix_resampled", "_get_stream_sampling_rate", "_instantiate", "_process_silence", "_get_audio_mix_rate", "_get_audio_speaker_mode", "_handles_file", "_write_begin", "_write_frame", "_write_end", "_parse_file", "_enter_tree", "_exit_tree", "_ready", "_get_configuration_warnings", "_input", "_shortcut_input", "_unhandled_input", "_unhandled_key_input", "_get_width", "_get_height", "_is_pixel_opaque", "_has_alpha", "_draw", "_draw_rect", "_draw_rect_region", "_get_packet_script", "_put_packet_script", "_get_packet_channel", "_get_packet_mode", "_set_transfer_channel", "_get_transfer_channel", "_set_transfer_mode", "_get_transfer_mode", "_set_target_peer", "_get_packet_peer", "_is_server", "_poll", "_close", "_disconnect_peer", "_get_unique_id", "_set_refuse_new_connections", "_is_refusing_new_connections", "_is_server_relay_supported", "_get_connection_status", "_set_multiplayer_peer", "_get_multiplayer_peer", "_get_peer_ids", "_rpc", "_get_remote_sender_id", "_object_configuration_add", "_object_configuration_remove", "_has_point", "_structured_text_parser", "_get_minimum_size", "_get_tooltip", "_get_drag_data", "_can_drop_data", "_drop_data", "_make_custom_tooltip", "_gui_input", "_pressed", "_toggled", "_value_changed", "_get_allowed_size_flags_horizontal", "_get_allowed_size_flags_vertical", "_play", "_set_paused", "_is_paused", "_set_audio_track", "_get_texture", "_update", "_get_channels", "_get_mix_rate", "_handle_unicode_input", "_backspace", "_cut", "_copy", "_paste", "_paste_primary_clipboard", "_confirm_code_completion", "_request_code_completion", "_filter_code_completion_candidates", "_get_line_syntax_highlighting", "_clear_highlighting_cache", "_update_cache", "_process_custom_fx", "_is_in_input_hotzone", "_is_in_output_hotzone", "_get_connection_line", "_is_node_hover_valid", "_post_process_key_value", "_get_child_nodes", "_get_parameter_list", "_get_child_by_name", "_get_parameter_default_value", "_is_parameter_read_only", "_get_caption", "_has_filter", "_get_aabb", "_input_event", "_mouse_enter", "_mouse_exit", "_get_shader_rid", "_get_shader_mode", "_can_do_next_pass", "_can_use_render_priority", "_get_description", "_get_category", "_get_return_icon_type", "_get_input_port_count", "_get_input_port_type", "_get_input_port_name", "_get_output_port_count", "_get_output_port_type", "_get_output_port_name", "_get_code", "_get_func_code", "_get_global_code", "_is_highend", "_is_available", "_mouse_shape_enter", "_mouse_shape_exit", "_use_tile_data_runtime_update", "_tile_data_runtime_update", "_execute", "_setup_modification", "_draw_editor_gizmo", "_get_surface_count", "_surface_get_array_len", "_surface_get_array_index_len", "_surface_get_arrays", "_surface_get_blend_shape_arrays", "_surface_get_lods", "_surface_get_format", "_surface_get_primitive_type", "_surface_set_material", "_surface_get_material", "_get_blend_shape_count", "_get_blend_shape_name", "_set_blend_shape_name", "_create_mesh_array", "_get_format", "_get_layered_type", "_get_layers", "_has_mipmaps", "_get_layer_data", "_get_depth", "_get_draw_rect", "_test_mask", "_import_preflight", "_get_supported_extensions", "_parse_node_extensions", "_parse_image_data", "_parse_texture_json", "_generate_scene_node", "_import_post_parse", "_import_node", "_import_post", "_export_preflight", "_convert_scene_node", "_export_node", "_export_post", "_get_connection_state", "_get_gathering_state", "_get_signaling_state", "_create_data_channel", "_create_offer", "_set_remote_description", "_set_local_description", "_add_ice_candidate", "_set_write_mode", "_get_write_mode", "_was_string_packet", "_get_ready_state", "_get_label", "_is_ordered", "_get_id", "_get_max_packet_life_time", "_get_max_retransmits", "_get_protocol", "_is_negotiated", "_get_buffered_amount", "_forward_canvas_gui_input", "_forward_canvas_draw_over_viewport", "_forward_canvas_force_draw_over_viewport", "_forward_3d_gui_input", "_forward_3d_draw_over_viewport", "_forward_3d_force_draw_over_viewport", "_get_plugin_name", "_get_plugin_icon", "_has_main_screen", "_make_visible", "_edit", "_handles", "_get_state", "_set_state", "_clear", "_save_external_data", "_apply_changes", "_get_breakpoints", "_set_window_layout", "_get_window_layout", "_build", "_enable_plugin", "_disable_plugin", "_get_importer_name", "_get_visible_name", "_get_preset_count", "_get_preset_name", "_get_import_options", "_get_save_extension", "_get_priority", "_get_import_order", "_get_option_visibility", "_import", "_run", "_redraw", "_get_handle_name", "_is_handle_highlighted", "_get_handle_value", "_set_handle", "_commit_handle", "_subgizmos_intersect_ray", "_subgizmos_intersect_frustum", "_set_subgizmo_transform", "_get_subgizmo_transform", "_commit_subgizmos", "_has_gizmo", "_create_gizmo", "_get_gizmo_name", "_can_be_hidden", "_is_selectable_when_hidden", "_generate", "_generate_from_path", "_generate_small_preview_automatically", "_can_generate_small_preview", "_make_tooltip_for_path", "_set_credentials", "_get_modified_files_data", "_stage_file", "_unstage_file", "_discard_file", "_commit", "_get_diff", "_shut_down", "_get_vcs_name", "_get_previous_commits", "_get_branch_list", "_get_remotes", "_create_branch", "_remove_branch", "_create_remote", "_remove_remote", "_get_current_branch_name", "_checkout_branch", "_pull", "_push", "_fetch", "_get_line_diff", "_get_supported_languages", "_export_file", "_export_begin", "_export_end", "_begin_customize_resources", "_customize_resource", "_begin_customize_scenes", "_customize_scene", "_get_customization_configuration_hash", "_end_customize_scenes", "_end_customize_resources", "_get_export_options", "_should_update_export_options", "_get_export_features", "_converts_to", "_convert", "_get_import_flags", "_get_extensions", "_import_scene", "_get_internal_import_options", "_get_internal_option_visibility", "_get_internal_option_update_view_required", "_internal_process", "_pre_process", "_post_process", "_can_handle", "_parse_begin", "_parse_category", "_parse_group", "_parse_property", "_parse_end", "_update_property", "_set_read_only", "_set_create_options", "_handle_menu_selected", "_is_active", "_get_file_extensions", "_query", "_post_import", "_setup_session", "_has_capture", "_capture"]