### PR TITLE
Ignore inline getter and setter as the variable as we already show the variable

### DIFF
--- a/addons/script-ide/plugin.gd
+++ b/addons/script-ide/plugin.gd
@@ -605,6 +605,11 @@ func for_each_script_member(script: Script, consumer: Callable):
 		else:
 			if hide_private_members && func_name.begins_with("_"):
 				continue
+				
+			# Inline getter/setter will normally be shown as '@...getter', '@...setter'.
+			# Since we already show the variable itself, we will skip those.
+			if (func_name.begins_with("@")):
+				continue
 			
 			consumer.call(outline_cache.funcs, func_name)
 	


### PR DESCRIPTION
Fixes: https://github.com/Maran23/script-ide/issues/31

Inline getter and setter are normally shown as `@...getter` and `@...setter`. 
They are therefore not found by the current scroll logic. 
Since they are somewhat attached to the variable, we skip and do not show them as function.