### PR TITLE
Fix empty popup when outline is initially closed

### DIFF
--- a/addons/script-ide/plugin.gd
+++ b/addons/script-ide/plugin.gd
@@ -319,6 +319,8 @@ func _unhandled_key_input(event: InputEvent) -> void:
 		outline_popup = POPUP_SCRIPT.new()
 		outline_popup.input_listener = _input
 
+		var outline_initially_closed: bool = not outline_container.is_visible_in_tree()
+		outline_container.show()
 		outline_container.reparent(outline_popup)
 
 		var script_editor: ScriptEditor = get_editor_interface().get_script_editor()
@@ -326,6 +328,8 @@ func _unhandled_key_input(event: InputEvent) -> void:
 			outline_container.reparent(split_container)
 			if (!is_outline_right):
 				split_container.move_child(outline_container, 0)
+			if outline_initially_closed:
+				outline_container.hide()
 
 			filter_txt.text = old_text
 


### PR DESCRIPTION
When the outline side panel is initially closed, and I open a popup, it appears empty.
![image](https://github.com/Maran23/script-ide/assets/52107553/948a3228-be84-42be-8ede-574d8a55b221)


So, the solution is to display the outline_container before reparenting it to the popup window. I have also implemented a check to ensure that the outline side panel reopens after the popup is closed if it was initially open, and remains closed if it was initially closed.