### PR TITLE
Added missing icon explanations to README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Features:
 	- (Static) Variables (Red)
 	- Engine callback functions (Blue)
 	- (Static) Functions (Green)
+		- Setter functions (Green circle, with an arrow inside it pointing to the right)
+		- Getter functions (Green circle, with an arrow inside it pointing to the left)
 - All the different members of the script can be hidden or made visible again by the outline filter. This allows fine control what should be visible (e.g. only signals, (Godot) functions, ...)
 - A `Right Click` enables only the clicked filter, another `Right Click` will enable all filters again
 - The Outline can be opened in a Popup with a defined shortcut for quick navigation between methods


### PR DESCRIPTION
Hi, I just downloaded this plugin and was confused about what the arrows inside the green icons mean. I couldn't find an issue about it or anything in google, so I spent about 15 minutes trying to figure it out. The icon .svg names gave me the solution. 

I added a one sentence explanation for each icon to the readme, as these were missing for the set and get functions. 

edit:
Perhaps the explanation could be clarified by adding that the arrows appear based on the function's name, and not based on what it actually does. I decided not to, as the explanations were already long.