### PR TITLE
Replace Dropdown with Checkbox for "Include Addons" Filter

### DIFF
--- a/addons/script-ide/quickopen/quick_open_panel.gd
+++ b/addons/script-ide/quickopen/quick_open_panel.gd
@@ -11,7 +11,7 @@ const STRUCTURE_END: StringName = &")"
 
 #region UI
 @onready var filter_bar: TabBar = %FilterBar
-@onready var search_option_btn: OptionButton = %SearchOptionBtn
+@onready var include_addons_check: CheckBox = %IncludeAddonsCheckbox
 @onready var filter_txt: LineEdit = %FilterTxt
 @onready var files_list: ItemList = %FilesList
 #endregion
@@ -31,7 +31,7 @@ var is_rebuild_cache: bool = true
 #region Plugin and Shortcut processing
 func _ready() -> void:
 	files_list.item_selected.connect(open_file)
-	search_option_btn.item_selected.connect(rebuild_cache_and_ui.unbind(1))
+	include_addons_check.toggled.connect(rebuild_cache_and_ui.unbind(1))
 	filter_txt.text_changed.connect(fill_files_list.unbind(1))
 
 	filter_bar.tab_changed.connect(change_fill_files_list.unbind(1))
@@ -83,10 +83,6 @@ func schedule_rebuild():
 	is_rebuild_cache = true
 
 func on_show():
-	if (search_option_btn.selected != 0):
-		search_option_btn.selected = 0
-
-		is_rebuild_cache = true
 
 	var rebuild_ui: bool = false
 	var all_tab_not_pressed: bool = filter_bar.current_tab != 0
@@ -143,7 +139,7 @@ func build_file_cache_dir(dir: EditorFileSystemDirectory):
 
 	for index: int in dir.get_file_count():
 		var file: String = dir.get_file_path(index)
-		if (search_option_btn.get_selected_id() == 0 && file.begins_with(ADDONS)):
+		if (!include_addons_check.button_pressed && file.begins_with(ADDONS)):
 			continue
 
 		var last_delimiter: int = file.rfind(&"/")

--- a/addons/script-ide/quickopen/quick_open_panel.tscn
+++ b/addons/script-ide/quickopen/quick_open_panel.tscn
@@ -125,15 +125,10 @@ tab_3/icon = SubResource("ImageTexture_grjtr")
 tab_4/title = "Other"
 tab_4/icon = SubResource("ImageTexture_xupch")
 
-[node name="SearchOptionBtn" type="OptionButton" parent="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="IncludeAddonsCheckbox" type="CheckBox" parent="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-selected = 0
-item_count = 2
-popup/item_0/text = "Project"
-popup/item_0/id = 0
-popup/item_1/text = "Project+Addons"
-popup/item_1/id = 1
+text = "Include Addons"
 
 [node name="FilterTxt" type="LineEdit" parent="PanelContainer/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true


### PR DESCRIPTION
Hi! I made a small UX improvement by replacing the existing dropdown "Search Options" with a single checkbox labeled "Include Addons".
Since there were only two options, this seemed like a more intuitive and quicker way for users to toggle the filter.

The goal is to streamline interaction while keeping the same functionality.

I understand there might be future plans to expand this field — if that's the case, feel free to disregard the change or let me know if you'd prefer a different approach!

![image](https://github.com/user-attachments/assets/d876da41-f4db-47ea-b644-b2fde6e4b9db)

![image](https://github.com/user-attachments/assets/fd52fdc6-f05d-4f74-9412-f2965f68bcf7)
