### PR TITLE
[Feature Proposal] Add custom run bar

### DIFF
--- a/addons/script-ide/customrunbar/custom_run_bar.gd
+++ b/addons/script-ide/customrunbar/custom_run_bar.gd
@@ -1,0 +1,16 @@
+@tool
+class_name CustomRunBar extends Control
+
+@export var buttons_container : HBoxContainer 
+
+func duplicate_engine_run_bar(engine_run_bar_buttons_container : Control) -> void:
+	for i in engine_run_bar_buttons_container.get_children().size():
+		var current_custom_run_bar_button: CustomRunBarButton = CustomRunBarButton.new()
+		var current_engine_run_bar_button = engine_run_bar_buttons_container.get_child(i)
+		
+		if current_engine_run_bar_button is Button:
+			current_custom_run_bar_button.mimic_engine_button(current_engine_run_bar_button)
+			buttons_container.add_child(current_custom_run_bar_button)
+		pass
+	pass
+	

--- a/addons/script-ide/customrunbar/custom_run_bar.tscn
+++ b/addons/script-ide/customrunbar/custom_run_bar.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=2 format=3 uid="uid://s7antvleeso"]
+
+[ext_resource type="Script" path="res://addons/script-ide/addons/script-ide/customrunbar/custom_run_bar.gd" id="1_o5ls6"]
+
+[node name="CustomRunBar" type="Control" node_paths=PackedStringArray("buttons_container")]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_o5ls6")
+buttons_container = NodePath("PanelContainer/HBoxContainer")
+
+[node name="PanelContainer" type="PanelContainer" parent="."]
+layout_mode = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer"]
+layout_mode = 2

--- a/addons/script-ide/customrunbar/custom_run_bar_button.gd
+++ b/addons/script-ide/customrunbar/custom_run_bar_button.gd
@@ -1,0 +1,16 @@
+@tool
+class_name CustomRunBarButton extends Button
+
+var engine_button : Button
+	
+func mimic_engine_button(engine_button : Button):
+	self.engine_button = engine_button
+	icon = engine_button.icon
+	flat = engine_button.flat
+	tooltip_text = engine_button.tooltip_text
+	focus_mode = engine_button.focus_mode
+	
+	pressed.connect(_on_pressed)
+	
+func _on_pressed():
+	engine_button.pressed.emit()


### PR DESCRIPTION
Hi ! 

I've done some modifications over the plugin for my own usage, ( I've let a comment about the filesystem tree in this [issue](https://github.com/Maran23/script-ide/issues/80) ), and I made this little feature too 

## Description :

Add a custom running bar directly into the script editor, this allow us to execute the game even if we use the script editor windowed in front of the engine editor ( it was useful for me especially on mac since on mac you can have only one window on full screen at time )

## Test :

Tested on Godot 4.3

Just activate the plugin and try every buttons : they should work as the run buttons from the engine editor one 


Its a little proposal but let me know 😄 