### PR TITLE
Godot 4.5 beta 4 - tab reorder fix

### DIFF
--- a/addons/script-ide/plugin.gd
+++ b/addons/script-ide/plugin.gd
@@ -1232,13 +1232,13 @@ func on_tab_bar_gui_input(event: InputEvent):
 				last_tab_hovered = -1
 
 func on_active_tab_rearranged(idx_to: int):
-	var control: Control = scripts_tab_container.get_tab_control(selected_tab)
-	if (!control):
-		return
-
-	scripts_tab_container.move_child(control, idx_to)
-	scripts_tab_container.current_tab = scripts_tab_container.current_tab
-	selected_tab = scripts_tab_container.current_tab
+	pass
+	# var control: Control = scripts_tab_container.get_tab_control(selected_tab)
+	# if (!control):
+	# 	return
+	# scripts_tab_container.move_child(control, idx_to)
+	# scripts_tab_container.current_tab = scripts_tab_container.current_tab
+	# selected_tab = scripts_tab_container.current_tab
 
 func get_res_path(idx: int) -> String:
 	var tab_control: Control = scripts_tab_container.get_tab_control(idx)


### PR DESCRIPTION
in Godot 4.5 beta4
editor settings:
text_editor/script_list/sort_members_outline_alphabetically - false
text_editor/script_list/sort_scripts_by - None

with this settings, moving tabs works incorrectly

- godot 4.5 seems like already reorders tabs internally before emitting `active_tab_rearranged`

- the plugin’s handler in on_active_tab_rearranged() still calls move_child(), which causes offset behavior (e.g., dragging tab 4 to slot 2 moves it to slot 3 instead).

- commenting it all out fixes it, but im not sure if it breaks something