### PR TITLE
Added suffix and path filters for quickopen

### DIFF
--- a/addons/script-ide/quickopen/filter_config.gd
+++ b/addons/script-ide/quickopen/filter_config.gd
@@ -1,0 +1,29 @@
+@tool
+class_name QuickOpenFilterConfig
+extends Resource
+
+signal config_changed
+
+@export var enable_extension_filter: bool = true:
+	set(value):
+		if enable_extension_filter != value:
+			enable_extension_filter = value
+			config_changed.emit()
+
+@export var excluded_extensions: PackedStringArray = ["import"]:
+	set(value):
+		if excluded_extensions != value:
+			excluded_extensions = value
+			config_changed.emit()
+
+@export var enable_path_filter: bool = true:
+	set(value):
+		if enable_path_filter != value:
+			enable_path_filter = value
+			config_changed.emit()
+
+@export var excluded_paths: PackedStringArray = ["res://.godot/"]:
+	set(value):
+		if excluded_paths != value:
+			excluded_paths = value
+			config_changed.emit()

--- a/addons/script-ide/quickopen/filter_config.gd.uid
+++ b/addons/script-ide/quickopen/filter_config.gd.uid
@@ -1,0 +1,1 @@
+uid://cggwfb8kcwr63

--- a/addons/script-ide/quickopen/filter_config.tres
+++ b/addons/script-ide/quickopen/filter_config.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="QuickOpenFilterConfig" load_steps=2 format=3 uid="uid://ddxqnnl5stevc"]
+
+[ext_resource type="Script" uid="uid://cggwfb8kcwr63" path="res://addons/script-ide/quickopen/filter_config.gd" id="1_config_script"]
+
+[resource]
+script = ExtResource("1_config_script")
+excluded_extensions = PackedStringArray("import")
+excluded_paths = PackedStringArray("res://.godot/")

--- a/addons/script-ide/quickopen/quick_open_panel.gd
+++ b/addons/script-ide/quickopen/quick_open_panel.gd
@@ -18,6 +18,10 @@ const STRUCTURE_END: StringName = &")"
 
 var plugin: EditorPlugin
 
+const FILTER_CONFIG_PATH: StringName = &"res://addons/script-ide/quickopen/filter_config.tres"
+
+var filter_config: Resource
+
 var scenes: Array[FileData]
 var scripts: Array[FileData]
 var resources: Array[FileData]
@@ -125,6 +129,19 @@ func on_show():
 func rebuild_cache():
 	is_rebuild_cache = false
 
+	if ResourceLoader.exists(FILTER_CONFIG_PATH):
+		filter_config = load(FILTER_CONFIG_PATH)
+	else:
+		# If the configuration gd file does not exist, a default one is created.
+		var QuickOpenFilterConfig = load("res://addons/script-ide/quickopen/filter_config.gd")
+		var new_config = QuickOpenFilterConfig.new()
+		ResourceSaver.save(new_config, FILTER_CONFIG_PATH)
+		filter_config = new_config
+
+	# Connect a signal to automatically rebuild the cache on configuration changes.
+	if filter_config and not filter_config.is_connected(&"config_changed", schedule_rebuild):
+		filter_config.connect(&"config_changed", schedule_rebuild)
+
 	all_files.clear()
 	scenes.clear()
 	scripts.clear()
@@ -162,6 +179,25 @@ func build_file_cache_dir(dir: EditorFileSystemDirectory):
 		var file: String = dir.get_file_path(index)
 		if (search_option_btn.get_selected_id() == 0 && file.begins_with(ADDONS)):
 			continue
+
+		# Exclude files based on configuration files.
+		if filter_config != null:
+			# Check if exclusions are by extension.
+			if filter_config.enable_extension_filter:
+				var extension: String = file.get_extension()
+				if extension in filter_config.excluded_extensions:
+					continue
+
+			# Check if the path is excluded.
+			if filter_config.enable_path_filter:
+				var is_excluded_by_path: bool = false
+				for path in filter_config.excluded_paths:
+					if not path.is_empty() and file.begins_with(path):
+						is_excluded_by_path = true
+						break
+				if is_excluded_by_path:
+					continue
+
 
 		var last_delimiter: int = file.rfind(&"/")
 


### PR DESCRIPTION
Hello,
I’ve become completely reliant on this plugin during my time using Godot.

The reason for this PR is that I foolishly added over 30,000 png and svg assets into my assets folder.
As a result, whenever I use Quick Open, unless I select a filter for scenes or GDScript files, every single keystroke causes a delay of two to three seconds — which is quite painful.

To solve this, I added a filtering feature that allows users to exclude certain file extensions or directory paths.
Users can configure this in res://addons/script-ide/quickopen/filter_config.tres.
By default, the .import suffix and .godot directory are included as examples for users to follow, even though Godot already filters them out at the engine level.
<img width="526" height="712" alt="image" src="https://github.com/user-attachments/assets/8ff8c9d5-6d40-4c47-90e8-039be2dd719a" />

I also added two switches to enable or disable these filters.

All of the changes take effect immediately — there’s no need to restart the plugin or the engine.

These improvements make a noticeable difference when dealing with tens of thousands of assets files,
though I fully admit that adding so many files to a game project is quite a foolish thing to do.

Here are a few example screenshots:

Default state
<img width="1813" height="894" alt="image" src="https://github.com/user-attachments/assets/c0d809a5-79ce-42a7-b1f1-ec9f6697296f" />

Filtered out the “素材 (assets)” path
<img width="1842" height="935" alt="image" src="https://github.com/user-attachments/assets/40b252b9-904f-4858-9d90-bd7ddc72b985" />

Filtered out .md extension
<img width="1804" height="965" alt="image" src="https://github.com/user-attachments/assets/b7b89ac1-f5d0-40f0-8e02-dba2f3c4feb8" />

Filters kept but switches turned off
<img width="1804" height="989" alt="image" src="https://github.com/user-attachments/assets/19412875-9908-4379-bbf1-681434f23a1f" />