### PR TITLE
Implement simple, readonly, horizontal Script Splitting

### DIFF
--- a/addons/script-ide/tabbar/custom_tab.gd
+++ b/addons/script-ide/tabbar/custom_tab.gd
@@ -9,7 +9,6 @@ signal dropped(source_index: int, target_index: int)
 var close_button: Button
 
 func _ready() -> void:
-	icon_alignment = HORIZONTAL_ALIGNMENT_LEFT
 	alignment = HORIZONTAL_ALIGNMENT_LEFT
 	action_mode = ACTION_MODE_BUTTON_PRESS
 	auto_translate_mode = Node.AUTO_TRANSLATE_MODE_DISABLED
@@ -53,7 +52,6 @@ func _get_drag_data(at_position: Vector2) -> Variant:
 	var preview: Button = Button.new()
 	preview.text = text
 	preview.icon = icon
-	preview.icon_alignment = HORIZONTAL_ALIGNMENT_LEFT
 	preview.alignment = HORIZONTAL_ALIGNMENT_LEFT
 	preview.auto_translate_mode = Node.AUTO_TRANSLATE_MODE_DISABLED
 	preview.add_theme_stylebox_override(&"normal", get_theme_stylebox(&"normal"))

--- a/addons/script-ide/tabbar/multiline_tab_container.gd
+++ b/addons/script-ide/tabbar/multiline_tab_container.gd
@@ -6,6 +6,7 @@ const CLOSE_BTN_SPACER: String = "    "
 const CustomTab := preload("custom_tab.gd")
 
 @onready var multiline_tab_bar: HFlowContainer = %MultilineTabBar
+@onready var split_btn: Button = %SplitBtn
 @onready var popup_btn: Button = %PopupBtn
 
 #region Theme
@@ -34,6 +35,8 @@ var plugin: EditorPlugin
 
 var suppress_theme_changed: bool
 
+var split: bool
+var split_icon: Texture2D
 var last_drag_over_tab: CustomTab
 var drag_marker: ColorRect
 var current_tab: CustomTab
@@ -44,11 +47,29 @@ func _init() -> void:
 #region Plugin and related tab handling processing
 func _ready() -> void:
 	popup_btn.pressed.connect(show_popup)
+	split_icon = split_btn.icon
 
 	set_process(false)
 
 	if (plugin != null):
 		schedule_update()
+
+func set_split(value: bool) -> void:
+	split = value
+
+	if (split):
+		split_btn.icon = split_icon
+
+		var text: String = scripts_item_list.get_item_text(current_tab.get_index())
+		var icon: Texture2D = scripts_item_list.get_item_icon(current_tab.get_index())
+		split_btn.text = text
+		split_btn.icon = icon
+	else:
+		split_btn.icon = split_icon
+		split_btn.text = ""
+
+func is_split() -> bool:
+	return split
 
 func _notification(what: int) -> void:
 	if (what == NOTIFICATION_DRAG_END || what == NOTIFICATION_MOUSE_EXIT):

--- a/addons/script-ide/tabbar/multiline_tab_container.tscn
+++ b/addons/script-ide/tabbar/multiline_tab_container.tscn
@@ -2,8 +2,12 @@
 
 [ext_resource type="Script" uid="uid://l1rdargfn67o" path="res://addons/script-ide/tabbar/multiline_tab_container.gd" id="1_8jr3v"]
 
+[sub_resource type="DPITexture" id="DPITexture_split"]
+_source = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\"><path fill=\"#e0e0e0\" d=\"M7.5 0v16h1V0z\"/></svg>
+"
+
 [sub_resource type="DPITexture" id="DPITexture_p4126"]
-_source = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\"><path fill=\"#e0e0e0\" fill-opacity=\".4\" d=\"M8 0a2 2 0 0 0 0 4 2 2 0 0 0 0-4zm0 6a2 2 0 0 0 0 4 2 2 0 0 0 0-4zm0 6a2 2 0 0 0 0 4 2 2 0 0 0 0-4z\"/></svg>
+_source = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\"><path fill=\"#e0e0e0\" d=\"M8 0a2 2 0 0 0 0 4 2 2 0 0 0 0-4zm0 6a2 2 0 0 0 0 4 2 2 0 0 0 0-4zm0 6a2 2 0 0 0 0 4 2 2 0 0 0 0-4z\"/></svg>
 "
 saturation = 1.8
 color_map = {
@@ -31,6 +35,14 @@ layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/h_separation = 0
 theme_override_constants/v_separation = 0
+
+[node name="SplitBtn" type="Button" parent="HBoxContainer" unique_id=813915450]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 8
+toggle_mode = true
+icon = SubResource("DPITexture_split")
+alignment = 0
 
 [node name="PopupBtn" type="Button" parent="HBoxContainer" unique_id=1586924518]
 unique_name_in_owner = true


### PR DESCRIPTION
Closes: https://github.com/Maran23/script-ide/issues/86

This implements Script Splitting in a very simple way.
It can only be done once, horizontally and the Script is readonly.
This is very useful for looking up things in other Scripts while working.

Script splitting is done with a button, and revoking the split is as easy as just clicking the button again.

<img width="1188" height="178" alt="image" src="https://github.com/user-attachments/assets/9b2ae78c-7400-4a4c-bde6-846b2a41a6e2" />

<img width="1366" height="923" alt="image" src="https://github.com/user-attachments/assets/89230fec-4daa-427a-a5b4-0ced8f66ec40" />

Why
--
As usual, this plugin tries to make as few changes as possible, especially in the Godot Editor itself. 

Just changing a bit in the Godot Editor structure can lead to very bad behavior or even crashes. 
Especially if something in Godot changed (which happens every release), everything will completely break and the plugin will only be compatible with some versions.

We had this issues in the past, but they were always minimal, and I would like to keep that. So while this is not the most powerful implementation, it will work and help a lot while not changing too much in the existing code or the Godot editor. Also, we do not need to care much about translation, theme and more, if we mostly stay compatible with Godot and use whats there.

So we have a low risk, and a high reward! Even though the Splitted Script is readonly, I don't had the feeling this is bad, most of the time you work on the left side and lookup things on the right side, even in the same file.

Future
--
I could imagine more adjustments, but would like to wait for feedback. Also, I'm thinking for a while to try to contribute some of the feature to Godot natively, but I don't have much time unfortunately.