### PR TITLE
Get script editor split from settings instead of the nodes value

### DIFF
--- a/addons/script-ide/plugin.gd
+++ b/addons/script-ide/plugin.gd
@@ -307,6 +307,9 @@ func _exit_tree() -> void:
 
 	if (!show_members):
 		set_setting(SHOW_MEMBERS, show_members)
+
+func _set_window_layout(configuration: ConfigFile):
+	script_editor_split_container.split_offset = configuration.get_value("ScriptEditor", "script_split_offset", 200)
 #endregion
 
 #region Plugin and Shortcut processing


### PR DESCRIPTION
On Linux, during startup the value of `script_editor_split_container.get_child(1).size.x` is not yet set with the values from the config. So the `update_outline_position()` method sets the split offset always to 200. This results in the outline view taking up most of the script editor.

With this change, the split_offset is being taken from the `editor_layout.cfg` after `update_outline_position()` has been called.
Should not impact Windows/Mac as I can see but a operating system check before this line could make it only run on Linux.

<img width="1997" height="1085" alt="image" src="https://github.com/user-attachments/assets/9def3bac-3a67-44ce-b112-db7d146891b5" />
